### PR TITLE
Fix 404 error due to `?` in `urlParams`

### DIFF
--- a/src/web/assets/src/js/autocomplete.js
+++ b/src/web/assets/src/js/autocomplete.js
@@ -203,7 +203,7 @@ function addHoverHandlerToMonaco(completionItems, autocompleteType, hasSubProper
 function getCompletionItemsFromEndpoint(fieldType = 'Twigfield', endpointUrl) {
   let urlParams = '';
   if (typeof fieldType !== 'undefined' && fieldType !== null) {
-    urlParams = '?fieldType=' + fieldType;
+    urlParams = (endpointUrl.includes('?') ? '&' : '?') + 'fieldType=' + fieldType;
   }
   // Only issue the XHR if we haven't loaded the autocompletes for this fieldType already
   if (typeof window.twigfieldFieldTypes === 'undefined') {


### PR DESCRIPTION
This is a quick (and dirty?) fix to the `urlParams` adding a second `?` to the endpoint URL, instead of a `&`, causing a 404 error. I'll leave it to you to figure out how you want to implement it.

<img width="664" alt="Screenshot 2022-06-22 at 20 32 04" src="https://user-images.githubusercontent.com/57572400/175112834-935511c1-b91d-4b3f-b04e-73e14f8ddd86.png">

